### PR TITLE
Fix namespace clash with uuid gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ require File.join(File.dirname(__FILE__), 'lib/uuidtools', 'version')
 
 PKG_DISPLAY_NAME   = 'UUIDTools'
 PKG_NAME           = PKG_DISPLAY_NAME.downcase
-PKG_VERSION        = UUID::VERSION::STRING
+PKG_VERSION        = UUIDTools::VERSION::STRING
 PKG_FILE_NAME      = "#{PKG_NAME}-#{PKG_VERSION}"
 
 RELEASE_NAME       = "REL #{PKG_VERSION}"

--- a/lib/uuidtools/version.rb
+++ b/lib/uuidtools/version.rb
@@ -22,8 +22,8 @@
 #++
 
 # Used to prevent the class/module from being loaded more than once
-unless defined? UUID::VERSION
-  class UUID
+unless defined? UUIDTools::VERSION
+  module UUIDTools
     module VERSION #:nodoc:
       MAJOR = 2
       MINOR = 1


### PR DESCRIPTION
Ruby 1.9 warns when constants are redefined.

The uuid gem and your uuidtools library both try to set the UUID::VERSION constant.
I've modified uuidtools to set the UUIDTools::VERSION constant instead.
