### PR TITLE
Refined memoization to silence warnings

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -376,43 +376,23 @@ module UUIDTools
 
     # Returns the hex digest of the UUID object.
     def hexdigest
-      return @hexdigest unless @hexdigest.nil?
-      if self.frozen?
-        return generate_hexdigest
-      else
-        return (@hexdigest = generate_hexdigest)
-      end
+      self.frozen? ? generate_hexdigest : (@hexdigest ||= generate_hexdigest)
     end
 
     # Returns the raw bytes that represent this UUID.
     def raw
-      return @raw unless @raw.nil?
-      if self.frozen?
-        return generate_raw
-      else
-        return (@raw = generate_raw)
-      end
+      self.frozen? ? generate_raw : (@raw ||= generate_raw)
     end
 
     # Returns a string representation for this UUID.
     def to_s
-      return @string unless @string.nil?
-      if self.frozen?
-        return generate_s
-      else
-        return (@string = generate_s)
-      end
+      self.frozen? ? generate_s : (@string ||= generate_s)
     end
     alias_method :to_str, :to_s
 
     # Returns an integer representation for this UUID.
     def to_i
-      return @integer unless @integer.nil?
-      if self.frozen?
-        return generate_i
-      else
-        return (@integer = generate_i)
-      end
+      self.frozen? ? generate_i : (@integer ||= generate_i)
     end
 
     # Returns a URI string for this UUID.
@@ -422,12 +402,7 @@ module UUIDTools
 
     # Returns an integer hash value.
     def hash
-      return @hash unless @hash.nil?
-      if self.frozen?
-        return generate_hash
-      else
-        return (@hash = generate_hash)
-      end
+      self.frozen? ? generate_hash : (@hash ||= generate_hash)
     end
 
     #These methods generate the appropriate representations the above methods cache

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+$VERBOSE=true
+
 spec_dir = File.expand_path(File.dirname(__FILE__))
 lib_dir = File.expand_path(File.join(spec_dir, "../lib"))
 


### PR DESCRIPTION
Retains behavior of memoization when the instance is not frozen and silences warnings about accessing instance variables that have not been initialized, e.g.
warning: instance variable @string not initialized
warning: instance variable @hexdigest not initialized
warning: instance variable @raw not initialized
warning: instance variable @integer not initialized
warning: instance variable @hash not initialized
