### PR TITLE
Deprecation Warning in Ruby 1.9.3

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -458,7 +458,7 @@ module UUIDTools
     def self.mac_address #:nodoc:
       if !defined?(@@mac_address)
         require 'rbconfig'
-        os_platform = Config::CONFIG['target_os']
+        os_platform = RbConfig::CONFIG['target_os']
         os_class = nil
         if (os_platform =~ /win/i && !(os_platform =~ /darwin/i)) ||
             os_platform =~ /w32/i


### PR DESCRIPTION
Hey sporkmonger,

Since 1.9.3 is out, and it has started printing pretty explicit warnings about deprecating Config in favor of RbConfig, I thought I'd go ahead and oblige. What do you think?

Regards,
René van den Berg
