### PR TITLE
Fix test wrt issue #12

### DIFF
--- a/spec/uuidtools/mac_address_spec.rb
+++ b/spec/uuidtools/mac_address_spec.rb
@@ -1,12 +1,8 @@
 require File.expand_path("../../spec_helper.rb", __FILE__)
 
-describe UUIDTools::UUID, "when obtaining a MAC address" do
+describe UUIDTools::UUID, "when obtaining a MAC address", :unless => UUIDTools::UUID.mac_address.nil? do
   before do
     @mac_address = UUIDTools::UUID.mac_address
-  end
-
-  it "should obtain a MAC address" do
-    @mac_address.should_not be_nil
   end
 
   it "should cache the MAC address" do

--- a/spec/uuidtools/uuid_creation_spec.rb
+++ b/spec/uuidtools/uuid_creation_spec.rb
@@ -13,7 +13,7 @@ describe UUIDTools::UUID, "when generating" do
     ).to_s.should == "15074785-9071-3fe3-89bd-876e4b9e919b"
   end
 
-  it "should correctly generate timestamp variant UUIDs" do
+  it "should correctly generate timestamp variant UUIDs", :unless => UUIDTools::UUID.mac_address.nil? do
     UUIDTools::UUID.timestamp_create.should_not be_random_node_id
     UUIDTools::UUID.timestamp_create.to_s.should_not ==
       UUIDTools::UUID.timestamp_create.to_s

--- a/spec/uuidtools/uuid_parsing_spec.rb
+++ b/spec/uuidtools/uuid_parsing_spec.rb
@@ -23,7 +23,7 @@ describe UUIDTools::UUID, "when parsing" do
     UUIDTools::UUID.timestamp_create.should_not be_nil_uuid
   end
 
-  it "should not treat a timestamp version UUID as a random node UUID" do
+  it "should not treat a timestamp version UUID as a random node UUID", :unless => UUIDTools::UUID.mac_address.nil? do
     UUIDTools::UUID.timestamp_create.should_not be_random_node_id
   end
 


### PR DESCRIPTION
It's very well possible that depending on the capabilities of the
process (and user) running the specs, the MAC address is not
available. In this case, do not fail tests, simply skip over those if
the mac address is unset.

Solves issue #12.
