### PR TITLE
Fix IP command

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -567,7 +567,7 @@ module UUIDTools
     def self.ip_path
       path = `which #{UUID.ip_command} 2>/dev/null`.strip
       path = UUID.ip_path_default if (path == "" && File.exist?(UUID.ip_path_default))
-      return (path === "" ? nil : "#{path} addr list")
+      return (path === "" ? nil : path)
     end
 
     #
@@ -579,7 +579,7 @@ module UUIDTools
 
       # if it does not exist, try the ip command
       if ifconfig_path == nil
-        ifconfig_path = UUID.ip_path
+        ifconfig_path = "#{UUID.ip_path} addr list"
         # all makes no sense when using ip(1)
         all = nil
       end


### PR DESCRIPTION
Running the command for ip isn't as simple as ifconfig.  You need to run `ip addr` or more specifically `ip addr list`.
