### PR TITLE
Make the UUID Regexp a separate constant

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -156,9 +156,7 @@ module UUIDTools
         raise TypeError,
           "Expected String, got #{uuid_string.class.name} instead."
       end
-      uuid_components = uuid_string.downcase.scan(
-        Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
-          "([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")).first
+      uuid_components = uuid_string.downcase.scan(UUIDTools::UUID_REGEXP).first
       raise ArgumentError, "Invalid UUID format." if uuid_components.nil?
       time_low = uuid_components[0].to_i(16)
       time_mid = uuid_components[1].to_i(16)
@@ -722,6 +720,11 @@ module UUIDTools
       return integer
     end
   end
+  
+  ##
+  # Constant Regexp that matches a UUID and captures its components.
+  UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
+                          "([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
 
   ##
   # Constant that represents the DNS namespace.


### PR DESCRIPTION
Other packages can test for UUID likeness by 'candidate =~ UUIDTools::UUID_REGEXP' without having to fully parse the UUID.
