### PR TITLE
Comparator operator returns nil when incomparable

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -393,6 +393,7 @@ module UUIDTools
     ##
     # Compares two UUIDs lexically
     def <=>(other_uuid)
+      return nil unless other_uuid.is_a?(UUIDTools::UUID)
       check = self.time_low <=> other_uuid.time_low
       return check if check != 0
       check = self.time_mid <=> other_uuid.time_mid


### PR DESCRIPTION
According to the Ruby docs, "If the other object is not comparable then the <=> operator should return nil."

This benchmark demonstrates the performance gains achieved through this added behavior:
https://gist.github.com/pszals/20266e5cbb2c6d42db73
