### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ rvm:
   - jruby
   - jruby-head
   - ree
+  - rbx-2
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-2
 script: "bundle exec rake"


### PR DESCRIPTION
Please add Rubinius to the build matrix with failure allowed.

I am trying to add this to ensure this Gem works in Rubinius and to complete this dashboard: http://bjfish.github.io/rubinius-gem-build-status/page3/.
