### PR TITLE
Update uuidtools.rb

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -511,7 +511,7 @@ module UUIDTools
     #
     # @api private
     def generate_raw
-      return self.class.convert_int_to_byte_string(self.to_i, 16)
+      return self.class.convert_int_to_byte_string(self.sto_i, 16)
     end
 
   public
@@ -629,6 +629,7 @@ module UUIDTools
           begin
             @@mac_address = UUID.first_mac `ipconfig /all`
           rescue
+            @@mac_address = nil          
           end
         else # linux, bsd, macos, solaris
           @@mac_address = UUID.first_mac(UUID.ifconfig(:all))


### PR DESCRIPTION
In rescue I set   @@mac_address = nil 
because if we do not this and if exception will be raise in `ipconfig /all` then  @@mac_address  will not be set and we got exception 
in below line    if @@mac_address != nil
See issue like :
2015-03-26 14:05:56 (+0:01:23.851) ERROR: NameError: uninitialized class variable @@mac_address in UUIDTools::UUID
	D:/IBM/LMT/wlp/usr/servers/server1/apps/tema.war/WEB-INF/gems/gems/uuidtools-2.1.5/lib/uuidtools.rb:637:in `mac_address'
	D:/IBM/LMT/wlp/usr/servers/server1/apps/tema.war/WEB-INF/gems/gems/uuidtools-2.1.5/lib/uuidtools.rb:242:in `timestamp_create'
	org/jruby/ext/thread/Mutex.java:149:in `synchronize'
	D:/IBM/LMT/wlp/usr/servers/server1/apps/tema.war/WEB-INF/gems/gems/uuidtools-2.1.5/lib/uuidtools.rb:232:in `timestamp_create'

or https://github.com/danmunn/redmine_dmsf/issues/122