### PR TITLE
Update uuidtools.rb

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -629,6 +629,7 @@ module UUIDTools
           begin
             @@mac_address = UUID.first_mac `ipconfig /all`
           rescue
+            @@mac_address = nil
           end
         else # linux, bsd, macos, solaris
           @@mac_address = UUID.first_mac(UUID.ifconfig(:all))


### PR DESCRIPTION
fix issue
ERROR: NameError: uninitialized class variable @@mac_address in UUIDTools::UUID
    D:/IBM/LMT/wlp/usr/servers/server1/apps/tema.war/WEB-INF/gems/gems/uuidtools-2.1.5/lib/uuidtools.rb:637:in `mac_address'
    D:/IBM/LMT/wlp/usr/servers/server1/apps/tema.war/WEB-INF/gems/gems/uuidtools-2.1.5/lib/uuidtools.rb:242:in`timestamp_create'
    org/jruby/ext/thread/Mutex.java:149:in `synchronize'
    D:/IBM/LMT/wlp/usr/servers/server1/apps/tema.war/WEB-INF/gems/gems/uuidtools-2.1.5/lib/uuidtools.rb:232:in`timestamp_create'
