### PR TITLE
Optimizations for UUID::parse_* and UUID::random_create

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -192,18 +192,29 @@ module UUIDTools
         raw_string.rjust(16, "\0")
       end
 
-      raw_bytes = (raw_string[0].respond_to? :ord) ? raw_string.chars.map(&:ord) : raw_string
-      time_low = ((raw_bytes[0] << 12) +
-                  (raw_bytes[1] << 8)  +
-                  (raw_bytes[2] << 4)  +
+      raw_bytes = []
+      if raw_string[0].respond_to? :ord
+        for i in 0...raw_string.size
+          raw_bytes << raw_string[i].ord
+        end
+      else
+        raw_bytes = raw_string
+      end
+
+      time_low = ((raw_bytes[0] << 24) +
+                  (raw_bytes[1] << 16)  +
+                  (raw_bytes[2] << 8)  +
                    raw_bytes[3])
-      time_mid = ((raw_bytes[4] << 4) +
+      time_mid = ((raw_bytes[4] << 8) +
                    raw_bytes[5])
-      time_hi_and_version = ((raw_bytes[6] << 4) +
+      time_hi_and_version = ((raw_bytes[6] << 8) +
                               raw_bytes[7])
       clock_seq_hi_and_reserved = raw_bytes[8]
       clock_seq_low = raw_bytes[9]
-      nodes = raw_bytes[10...16]
+      nodes = []
+      for i in 10...16
+        nodes << raw_bytes[i]
+      end
 
       return self.new(time_low, time_mid, time_hi_and_version,
                       clock_seq_hi_and_reserved, clock_seq_low, nodes)
@@ -755,7 +766,7 @@ module UUIDTools
 
       integer = 0
       size = byte_string.size
-      if byte_string[0].respond_to?(:ord)
+      if byte_string[0].respond_to? :ord
         for i in 0...size
           integer += (byte_string[i].ord << (((size - 1) - i) * 8))
         end

--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -178,19 +178,35 @@ module UUIDTools
         raise TypeError,
           "Expected String, got #{raw_string.class.name} instead."
       end
-      integer = self.convert_byte_string_to_int(raw_string)
 
-      time_low = (integer >> 96) & 0xFFFFFFFF
-      time_mid = (integer >> 80) & 0xFFFF
-      time_hi_and_version = (integer >> 64) & 0xFFFF
-      clock_seq_hi_and_reserved = (integer >> 56) & 0xFF
-      clock_seq_low = (integer >> 48) & 0xFF
-      nodes = []
-      for i in 0..5
-        nodes << ((integer >> (40 - (i * 8))) & 0xFF)
+      if raw_string.respond_to?(:force_encoding)
+        raw_string.force_encoding(Encoding::ASCII_8BIT)
       end
+
+      unless raw_string.length == 16
+        # Option A: Enforce raw_string be 16 characters (More strict)
+        #raise ArgumentError,
+        #  "Expected 16 bytes, got #{raw_string.length} instead."
+
+        # Option B: Pad raw_string to 16 characters (Compatible with existing behavior)
+        raw_string.rjust(16, "\0")
+      end
+
+      raw_bytes = (raw_string[0].respond_to? :ord) ? raw_string.chars.map(&:ord) : raw_string
+      time_low = ((raw_bytes[0] << 12) +
+                  (raw_bytes[1] << 8)  +
+                  (raw_bytes[2] << 4)  +
+                   raw_bytes[3])
+      time_mid = ((raw_bytes[4] << 4) +
+                   raw_bytes[5])
+      time_hi_and_version = ((raw_bytes[6] << 4) +
+                              raw_bytes[7])
+      clock_seq_hi_and_reserved = raw_bytes[8]
+      clock_seq_low = raw_bytes[9]
+      nodes = raw_bytes[10...16]
+
       return self.new(time_low, time_mid, time_hi_and_version,
-        clock_seq_hi_and_reserved, clock_seq_low, nodes)
+                      clock_seq_hi_and_reserved, clock_seq_low, nodes)
     end
 
     ##
@@ -200,17 +216,42 @@ module UUIDTools
         raise ArgumentError,
           "Expected Integer, got #{uuid_int.class.name} instead."
       end
-      return self.parse_raw(self.convert_int_to_byte_string(uuid_int, 16))
+
+      time_low = (uuid_int >> 96) & 0xFFFFFFFF
+      time_mid = (uuid_int >> 80) & 0xFFFF
+      time_hi_and_version = (uuid_int >> 64) & 0xFFFF
+      clock_seq_hi_and_reserved = (uuid_int >> 56) & 0xFF
+      clock_seq_low = (uuid_int >> 48) & 0xFF
+      nodes = []
+      for i in 0..5
+        nodes << ((uuid_int >> (40 - (i * 8))) & 0xFF)
+      end
+
+      return self.new(time_low, time_mid, time_hi_and_version,
+                      clock_seq_hi_and_reserved, clock_seq_low, nodes)
     end
 
     ##
     # Parse a UUID from a hexdigest String.
-    def self.parse_hexdigest(uuid_hexdigest)
-      unless uuid_hexdigest.kind_of?(String)
+    def self.parse_hexdigest(uuid_hex)
+      unless uuid_hex.kind_of?(String)
         raise ArgumentError,
-          "Expected String, got #{uuid_hexdigest.class.name} instead."
+          "Expected String, got #{uuid_hex.class.name} instead."
       end
-      return self.parse_int(uuid_hexdigest.to_i(16))
+
+      time_low = uuid_hex[0...8].to_i(16)
+      time_mid = uuid_hex[8...12].to_i(16)
+      time_hi_and_version = uuid_hex[12...16].to_i(16)
+      clock_seq_hi_and_reserved = uuid_hex[16...18].to_i(16)
+      clock_seq_low = uuid_hex[18...20].to_i(16)
+      nodes_string = uuid_hex[20...32]
+      nodes = []
+      for i in 0..5
+        nodes << nodes_string[(i * 2)..(i * 2) + 1].to_i(16)
+      end
+
+      return self.new(time_low, time_mid, time_hi_and_version,
+                      clock_seq_hi_and_reserved, clock_seq_low, nodes)
     end
 
     ##
@@ -711,13 +752,19 @@ module UUIDTools
       if byte_string.respond_to?(:force_encoding)
         byte_string.force_encoding(Encoding::ASCII_8BIT)
       end
+
       integer = 0
       size = byte_string.size
-      for i in 0..(size - 1)
-        ordinal = (byte_string[i].respond_to?(:ord) ?
-          byte_string[i].ord : byte_string[i])
-        integer += (ordinal << (((size - 1) - i) * 8))
+      if byte_string[0].respond_to?(:ord)
+        for i in 0...size
+          integer += (byte_string[i].ord << (((size - 1) - i) * 8))
+        end
+      else
+        for i in 0...size
+          integer += (byte_string[i] << (((size - 1) - i) * 8))
+        end
       end
+      
       return integer
     end
   end

--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -183,13 +183,19 @@ module UUIDTools
         raw_string.force_encoding(Encoding::ASCII_8BIT)
       end
 
-      unless raw_string.length == 16
+      raw_length = raw_string.length
+      if raw_length < 16
         # Option A: Enforce raw_string be 16 characters (More strict)
         #raise ArgumentError,
         #  "Expected 16 bytes, got #{raw_string.length} instead."
 
         # Option B: Pad raw_string to 16 characters (Compatible with existing behavior)
-        raw_string.rjust(16, "\0")
+        raw_string = raw_string.rjust(16, "\0")
+      elsif raw_length > 16
+        # NOTE: As per "Option B" above, existing behavior would use the lower
+        # 128-bits of an overly long raw_string instead of using the upper 128-bits.
+        start_index = raw_length - 16
+        raw_string = raw_string[start_index...raw_length]
       end
 
       raw_bytes = []

--- a/spec/uuidtools/uuid_parsing_spec.rb
+++ b/spec/uuidtools/uuid_parsing_spec.rb
@@ -125,4 +125,23 @@ describe UUIDTools::UUID, "when parsing" do
     uuid = UUIDTools::UUID.timestamp_create
     expect(UUIDTools::UUID.parse_hexdigest(uuid.hexdigest)).to eql(uuid)
   end
+
+  it "should correctly parse raw bytes" do
+    # NOTE: Short Input
+    expect(UUIDTools::UUID.new(0, 0, 0, 0, 0, [0, 0, 0, 0, 0, 0])).to eql(
+      UUIDTools::UUID.parse_raw(""))
+
+    # NOTE: Nil Input
+    expect(UUIDTools::UUID.parse_raw(
+      "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+    )).to be_nil_uuid
+
+    # NOTE: Realistic Input
+    uuid = UUIDTools::UUID.timestamp_create
+    expect(UUIDTools::UUID.parse_raw(uuid.raw)).to eql(uuid)
+
+    # NOTE: Long input
+    raw192bit = "\1\2\3\4\5\6\7\8" + uuid.raw
+    expect(UUIDTools::UUID.parse_raw(raw192bit)).to eql(uuid)
+  end
 end

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -1,38 +1,55 @@
 task :benchmark do
-  require 'lib/uuidtools'
   require 'benchmark'
+  require_relative '../lib/uuidtools'
 
-  # Version 1
-  result = Benchmark.measure do
-    10000.times do
-      UUID.timestamp_create.to_s
-    end
+  def format_float(float)
+    ("%.2f" % float).rjust(9, ' ')
   end
-  puts "#{(10000.0 / result.real)} version 1 per second."
 
-  # Version 3
-  result = Benchmark.measure do
-    10000.times do
-      UUID.md5_create(UUID_URL_NAMESPACE,
-        "http://www.ietf.org/rfc/rfc4122.txt").to_s
-    end
+  def format_result(result, action, iterations)
+    $stdout.puts "#{format_float(iterations / result.real)} | #{action}"
   end
-  puts "#{(10000.0 / result.real)} version 3 per second."
 
-  # Version 4
-  result = Benchmark.measure do
-    10000.times do
-      UUID.random_create.to_s
+  def benchmark(name, n: 10000)
+    result = Benchmark.measure do
+      n.times { yield }
     end
-  end
-  puts "#{(10000.0 / result.real)} version 4 per second."
 
-  # Version 5
-  result = Benchmark.measure do
-    10000.times do
-      UUID.sha1_create(UUID_URL_NAMESPACE,
-        "http://www.ietf.org/rfc/rfc4122.txt").to_s
-    end
+    format_result(result, name, n)
   end
-  puts "#{(10000.0 / result.real)} version 5 per second."
+
+  $stdout.puts ' x/second | Benchmark'
+  $stdout.puts '---------- -----------'
+
+  ##
+  # Benchmark UUID creation
+  namespace = UUIDTools::UUID_URL_NAMESPACE
+  url = "http://www.ietf.org/rfc/rfc4122.txt"
+
+  benchmark('Version 1') { UUIDTools::UUID.timestamp_create.to_s }
+  benchmark('Version 3') { UUIDTools::UUID.md5_create(namespace, url).to_s }
+  benchmark('Version 4') { UUIDTools::UUID.random_create.to_s }
+  benchmark('Version 5') { UUIDTools::UUID.sha1_create(namespace, url).to_s }
+
+  ## 
+  # Benchmark UUID parsing
+  uuid_s = UUIDTools::UUID.random_create.to_s
+  benchmark('UUID::parse', n: 40000) { UUIDTools::UUID.parse(uuid_s) }
+
+  uuid_raw = UUIDTools::UUID.random_create.raw
+  benchmark('UUID::parse_raw', n: 40000) { UUIDTools::UUID.parse_raw(uuid_raw) }
+
+  uuid_i = UUIDTools::UUID.random_create.to_i
+  benchmark('UUID::parse_int', n: 40000) { UUIDTools::UUID.parse_int(uuid_i) }
+
+  uuid_hex = UUIDTools::UUID.random_create.hexdigest
+  benchmark('UUID::parse_hexdigest', n: 40000) { UUIDTools::UUID.parse_hexdigest(uuid_hex) }
+
+  ##
+  # Benchmark UUID private api
+  byte_string = UUIDTools::UUID.timestamp_create.raw
+  benchmark('UUID::convert_byte_string_to_int') { UUIDTools::UUID.convert_byte_string_to_int(byte_string) }
+
+  bigint = UUIDTools::UUID.timestamp_create.to_i
+  benchmark('UUID::convert_int_to_byte_string') { UUIDTools::UUID.convert_int_to_byte_string(bigint, 16) }
 end

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -1,6 +1,10 @@
 task :benchmark do
   require 'benchmark'
-  require_relative '../lib/uuidtools'
+  if Kernel.method_defined? :require_relative
+    require_relative '../lib/uuidtools'
+  else
+    require 'lib/uuidtools'
+  end
 
   def format_float(float)
     ("%.2f" % float).rjust(9, ' ')

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -10,7 +10,7 @@ task :benchmark do
     $stdout.puts "#{format_float(iterations / result.real)} | #{action}"
   end
 
-  def benchmark(name, n: 10000)
+  def benchmark(name, n = 10000)
     result = Benchmark.measure do
       n.times { yield }
     end
@@ -34,16 +34,16 @@ task :benchmark do
   ## 
   # Benchmark UUID parsing
   uuid_s = UUIDTools::UUID.random_create.to_s
-  benchmark('UUID::parse', n: 40000) { UUIDTools::UUID.parse(uuid_s) }
+  benchmark('UUID::parse', 40000) { UUIDTools::UUID.parse(uuid_s) }
 
   uuid_raw = UUIDTools::UUID.random_create.raw
-  benchmark('UUID::parse_raw', n: 40000) { UUIDTools::UUID.parse_raw(uuid_raw) }
+  benchmark('UUID::parse_raw', 40000) { UUIDTools::UUID.parse_raw(uuid_raw) }
 
   uuid_i = UUIDTools::UUID.random_create.to_i
-  benchmark('UUID::parse_int', n: 40000) { UUIDTools::UUID.parse_int(uuid_i) }
+  benchmark('UUID::parse_int', 40000) { UUIDTools::UUID.parse_int(uuid_i) }
 
   uuid_hex = UUIDTools::UUID.random_create.hexdigest
-  benchmark('UUID::parse_hexdigest', n: 40000) { UUIDTools::UUID.parse_hexdigest(uuid_hex) }
+  benchmark('UUID::parse_hexdigest', 40000) { UUIDTools::UUID.parse_hexdigest(uuid_hex) }
 
   ##
   # Benchmark UUID private api

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -1,10 +1,8 @@
 task :benchmark do
   require 'benchmark'
-  if Kernel.method_defined? :require_relative
-    require_relative '../lib/uuidtools'
-  else
-    require 'lib/uuidtools'
-  end
+
+  $LOAD_PATH.unshift File.expand_path('../..', __FILE__)
+  require 'lib/uuidtools'
 
   def format_float(float)
     ("%.2f" % float).rjust(9, ' ')


### PR DESCRIPTION
Improves performance substantially on `parse_raw`, `parse_int`, `parse_hexdigest` and `random_create`.
Performance for other methods are unaffected.

I've done my best to keep the behavior unchanged, even where the behavior doesn't appear covered by rspec.

Tested with ruby-1.9.3 and ruby-2.1.2.
