### PR TITLE
Rescue from failure when neither ip nor ifconfig exists

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -585,6 +585,8 @@ module UUIDTools
 
       all_switch = all == nil ? "" : "-a"
       return `#{ifconfig_path} #{all_switch}` if not ifconfig_path == nil
+    rescue
+      ''
     end
 
     # Match and return the first Mac address found
@@ -625,13 +627,14 @@ module UUIDTools
 
         os_class = UUID.os_class
 
-        if os_class == :windows
-          begin
+        begin
+          if os_class == :windows
             @@mac_address = UUID.first_mac `ipconfig /all`
-          rescue
+          else # linux, bsd, macos, solaris
+            @@mac_address = UUID.first_mac(UUID.ifconfig(:all))
           end
-        else # linux, bsd, macos, solaris
-          @@mac_address = UUID.first_mac(UUID.ifconfig(:all))
+        rescue
+          @@mac_address = nil
         end
 
         if @@mac_address != nil

--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -627,15 +627,16 @@ module UUIDTools
 
         os_class = UUID.os_class
 
-        begin
-          if os_class == :windows
-            @@mac_address = UUID.first_mac `ipconfig /all`
-          else # linux, bsd, macos, solaris
-            @@mac_address = UUID.first_mac(UUID.ifconfig(:all))
+        @@mac_address =
+          begin
+            if os_class == :windows
+              UUID.first_mac(`ipconfig /all`)
+            else # linux, bsd, macos, solaris
+              UUID.first_mac(UUID.ifconfig(:all))
+            end
+          rescue
+            nil
           end
-        rescue
-          @@mac_address = nil
-        end
 
         if @@mac_address != nil
           if @@mac_address.respond_to?(:to_str)

--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -586,7 +586,7 @@ module UUIDTools
       all_switch = all == nil ? "" : "-a"
       return `#{ifconfig_path} #{all_switch}` if not ifconfig_path == nil
     rescue
-      ''
+      ""
     end
 
     # Match and return the first Mac address found

--- a/spec/uuidtools/mac_address_spec.rb
+++ b/spec/uuidtools/mac_address_spec.rb
@@ -249,6 +249,28 @@ describe UUIDTools::UUID, "when obtaining a MAC address" do
   end
 end
 
+describe UUIDTools::UUID, "when neither ip nor ifconfig exists" do
+  it "should not fail" do
+    save_ifconfig_command = UUIDTools::UUID.ifconfig_command
+    save_ifconfig_path_default = UUIDTools::UUID.ifconfig_path_default
+    save_ip_command = UUIDTools::UUID.ip_command
+    save_ip_path_default = UUIDTools::UUID.ip_path_default
+
+    UUIDTools::UUID.ifconfig_command = "nonexistent"
+    UUIDTools::UUID.ifconfig_path_default = "/bin/nonexistent"
+    UUIDTools::UUID.ip_command = "nonexistent"
+    UUIDTools::UUID.ip_path_default = "/bin/nonexistent"
+
+    expect(UUIDTools::UUID.ifconfig).to eq('')
+
+    UUIDTools::UUID.ifconfig_command = save_ifconfig_command
+    UUIDTools::UUID.ifconfig_path_default = save_ifconfig_path_default
+    UUIDTools::UUID.ip_command = save_ip_command
+    UUIDTools::UUID.ip_path_default = save_ip_path_default
+
+  end
+end
+
 describe UUIDTools::UUID, "before obtaining a MAC address" do
 
   before do

--- a/spec/uuidtools/mac_address_spec.rb
+++ b/spec/uuidtools/mac_address_spec.rb
@@ -261,13 +261,12 @@ describe UUIDTools::UUID, "when neither ip nor ifconfig exists" do
     UUIDTools::UUID.ip_command = "nonexistent"
     UUIDTools::UUID.ip_path_default = "/bin/nonexistent"
 
-    expect(UUIDTools::UUID.ifconfig).to eq('')
+    expect(UUIDTools::UUID.ifconfig).to eq("")
 
     UUIDTools::UUID.ifconfig_command = save_ifconfig_command
     UUIDTools::UUID.ifconfig_path_default = save_ifconfig_path_default
     UUIDTools::UUID.ip_command = save_ip_command
     UUIDTools::UUID.ip_path_default = save_ip_path_default
-
   end
 end
 


### PR DESCRIPTION
Hi, @sporkmonger!

I'm now working with some chroot-ed Linux environment where neither `ip` nor `ifconfig` command is accessible. In such an environment I've found that `UUIDTools::UUID.ifconfig` fails in trying to invoke an incomplete command such as `" addr list"` (path of `ip` is missing!).

This patch makes the method ignore such a failure and return an empty string.
