### PR TITLE
Stop parsing if garbage exists around UUID

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -724,8 +724,8 @@ module UUIDTools
 
   ##
   # Constant Regexp that matches a UUID and captures its components.
-  UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
-                          "([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
+  UUID_REGEXP = Regexp.new("\\A([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
+                          "([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})\\z")
 
   ##
   # Constant that represents the DNS namespace.


### PR DESCRIPTION
UUIDTools::UUID.parse can parse string that has garbage around UUID.

```
s = SecureRandom.uuid # => "31a6b11d-06be-42b7-8800-53038da42ebe"
UUIDTools::UUID.parse("foo\n" + s + "\nbar") # => #<UUID:0x3fed7590a9dc UUID:31a6b11d-06be-42b7-8800-53038da42ebe>
```

This means  UUIDTools::UUID.parse can't use for validation.
