### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -24,7 +24,7 @@ require 'thread'
 require 'digest/sha1'
 require 'digest/md5'
 
-require 'uuidtools/version'
+require_relative 'uuidtools/version'
 
 begin
   require 'securerandom'


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>