### PR TITLE
Gracefully fall back to other strategies when MAC address cannot be determined

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -631,22 +631,19 @@ module UUIDTools
     # Call the ifconfig or ip command that is found
     #
     def self.ifconfig(all=nil)
-      # find the path of the ifconfig command
-      ifconfig_path = UUID.ifconfig_path
-
-      # if it does not exist, try the ip command
-      if ifconfig_path == nil
-        ifconfig_path = "#{UUID.ip_path} addr list"
-        # all makes no sense when using ip(1)
-        all = nil
-      end
-
-      all_switch = all == nil ? "" : "-a"
-      return `#{ifconfig_path} #{all_switch}` if not ifconfig_path == nil
+      command =
+        if ifconfig_path=UUID.ifconfig_path
+          "#{ifconfig_path}#{all ? " -a" : ""}"
+        elsif ip_path=UUID.ip_path
+          "#{ip_path} addr list"
+        end
+      `#{command}` if command
     end
 
     # Match and return the first Mac address found
     def self.first_mac(instring)
+      return nil if instring.nil?
+
       mac_regexps = [
         Regexp.new("address:? (#{(["[0-9a-fA-F]{2}"] * 6).join(":")})"),
         Regexp.new("addr:? (#{(["[0-9a-fA-F]{2}"] * 6).join(":")})"),
@@ -679,6 +676,7 @@ module UUIDTools
     # Returns nil if a MAC address could not be found.
     def self.mac_address
       if !defined?(@@mac_address)
+        @@mac_address = nil
         require 'rbconfig'
 
         os_class = UUID.os_class
@@ -688,8 +686,9 @@ module UUIDTools
             @@mac_address = UUID.first_mac `ipconfig /all`
           rescue
           end
-        else # linux, bsd, macos, solaris
-          @@mac_address = UUID.first_mac(UUID.ifconfig(:all))
+        elsif ifconfig_output=UUID.ifconfig(:all)
+          # linux, bsd, macos, solaris
+          @@mac_address = UUID.first_mac ifconfig_output
         end
 
         if @@mac_address != nil

--- a/spec/uuidtools/mac_address_spec.rb
+++ b/spec/uuidtools/mac_address_spec.rb
@@ -213,7 +213,8 @@ samples = {
   :openbsd => openbsd_sample,
   :linux => linux_sample,
   :linux2 => linux_sample_2,
-  :linuxip => linux_ip_sample
+  :linuxip => linux_ip_sample,
+  :docker => nil
 }
 
 macs = {
@@ -450,5 +451,10 @@ describe UUIDTools::UUID, "before obtaining a MAC address" do
   it "should be able to parse ip addr output" do
     mac = UUIDTools::UUID.first_mac samples[:linuxip]
     expect(mac).to eql(macs[:linuxip])
+  end
+
+  it "should return nil when unable to identify the mac address" do
+    mac = UUIDTools::UUID.first_mac nil
+    expect(mac).to be_nil
   end
 end


### PR DESCRIPTION
Often in containerized *nix environments, neither `ip` nor `ifconfig` will be present, which means that in these environments, the MAC address cannot be determined. In such a scenario, certain strategies would fail to generate a UUID.

This change makes the code fall back to other strategies without raising errors when the MAC address cannot be determined.

Fixes #53