### PR TITLE
Consider v6, v7, v8 to be valid UUIDs

### DIFF
--- a/lib/uuidtools.rb
+++ b/lib/uuidtools.rb
@@ -417,7 +417,7 @@ module UUIDTools
     # Returns true if this UUID is valid.
     def valid?
       if [0b000, 0b100, 0b110, 0b111].include?(self.variant) &&
-        (1..5).include?(self.version)
+        (1..8).include?(self.version)
         return true
       else
         return false

--- a/spec/uuidtools/uuid_parsing_spec.rb
+++ b/spec/uuidtools/uuid_parsing_spec.rb
@@ -76,6 +76,10 @@ describe UUIDTools::UUID, "when parsing" do
     end.to raise_error(ArgumentError)
   end
 
+  it "should parse v7 UUIDs as valid" do
+    expect(UUIDTools::UUID.parse("01957ca6-fc1a-7322-956e-e9e6c53cab55")).to be_valid
+  end
+
   it "should allow for sorting of UUID arrays" do
     uuids = []
     1000.times do


### PR DESCRIPTION
Doesn't add support for v6-8 (#56), but UUIDTools will no longer consider them invalid UUIDs.